### PR TITLE
Update for when post sync arguments don't include the full meta.

### DIFF
--- a/ElasticPressGeoFeature.php
+++ b/ElasticPressGeoFeature.php
@@ -113,32 +113,32 @@ class ElasticPressGeoFeature extends \ElasticPress\Feature {
 			$meta = $post_args['meta'];
 
 			if ( ! empty( $meta['latitude'][0]['double'] ) ) {
-				$geo_point['location']['lat'] = $meta['latitude'][0]['double'];
+				$geo_point['location']['lat'] =  (float) number_format( $meta['latitude'][0]['double'], 6, '.', '' );
 			}
 
 			if ( ! empty( $meta['longitude'][0]['double'] ) ) {
-				$geo_point['location']['lon'] = $meta['longitude'][0]['double'];
+				$geo_point['location']['lon'] = (float) number_format( $meta['longitude'][0]['double'], 6, '.', '' );
 			}
 		} elseif ( isset( $post_args['post_meta'] ) && isset( $post_args['post_meta']['latitude'] ) ) {
 			// Handle legacy post_meta property, for older versions of elasticpress.
 			$post_meta = $post_args['post_meta'];
 
 			if ( isset( $post_meta['latitude'][0] ) ) {
-				$geo_point['location']['lat'] = $post_meta['latitude'][0];
+				$geo_point['location']['lat'] = (float) number_format( $post_meta['latitude'][0], 6, '.', '' );
 			}
 
 			if ( isset( $post_meta['longitude'][0] ) ) {
-				$geo_point['location']['lon'] = $post_meta['longitude'][0];
+				$geo_point['location']['lon'] = (float) number_format( $post_meta['longitude'][0], 6, '.', '' );
 			}
 		} elseif ( !empty( get_post_meta( $post_id, 'latitude', true ) ) ) {
 
-			$lat = get_post_meta( $post_id, 'latitude', true );
+			$lat = (float) number_format( get_post_meta( $post_id, 'latitude', true ), 6, '.', '' );
 			if ( ! empty( $lat ) ) {
 				$geo_point['location']['lat'] = $lat;
 				$post_args['meta']['latitude'][0]['double'] = $lat;
 			}
 
-			$lon = get_post_meta( $post_id, 'longitude', true );
+			$lon = (float) number_format( get_post_meta( $post_id, 'longitude', true ), 6, '.', '' );
 			if ( ! empty( $lon ) ) {
 				$geo_point['location']['lon'] = $lon;
 				$post_args['meta']['longitude'][0]['double'] = $lon;

--- a/ElasticPressGeoFeature.php
+++ b/ElasticPressGeoFeature.php
@@ -132,14 +132,14 @@ class ElasticPressGeoFeature extends \ElasticPress\Feature {
 			}
 		} elseif ( !empty( get_post_meta( $post_id, 'latitude', true ) ) ) {
 
-			if ( ! empty( $meta['latitude'][0]['double'] ) ) {
-				$lat = get_post_meta( $post_id, 'latitude', true );
+			$lat = get_post_meta( $post_id, 'latitude', true );
+			if ( ! empty( $lat ) ) {
 				$geo_point['location']['lat'] = $lat;
 				$post_args['meta']['latitude'][0]['double'] = $lat;
 			}
 
-			if ( ! empty( $meta['longitude'][0]['double'] ) ) {
-				$lon = get_post_meta( $post_id, 'longitude', true );
+			$lon = get_post_meta( $post_id, 'longitude', true );
+			if ( ! empty( $lon ) ) {
 				$geo_point['location']['lon'] = $lon;
 				$post_args['meta']['longitude'][0]['double'] = $lon;
 			}

--- a/ElasticPressGeoFeature.php
+++ b/ElasticPressGeoFeature.php
@@ -109,7 +109,7 @@ class ElasticPressGeoFeature extends \ElasticPress\Feature {
 			'location' => [],
 		];
 
-		if ( isset( $post_args['meta'] ) ) {
+		if ( isset( $post_args['meta'] ) && isset( $post_args['meta']['latitude'] ) ) {
 			$meta = $post_args['meta'];
 
 			if ( ! empty( $meta['latitude'][0]['double'] ) ) {
@@ -119,7 +119,7 @@ class ElasticPressGeoFeature extends \ElasticPress\Feature {
 			if ( ! empty( $meta['longitude'][0]['double'] ) ) {
 				$geo_point['location']['lon'] = $meta['longitude'][0]['double'];
 			}
-		} elseif ( isset( $post_args['post_meta'] ) ) {
+		} elseif ( isset( $post_args['post_meta'] ) && isset( $post_args['post_meta']['latitude'] ) ) {
 			// Handle legacy post_meta property, for older versions of elasticpress.
 			$post_meta = $post_args['post_meta'];
 

--- a/ElasticPressGeoFeature.php
+++ b/ElasticPressGeoFeature.php
@@ -130,6 +130,19 @@ class ElasticPressGeoFeature extends \ElasticPress\Feature {
 			if ( isset( $post_meta['longitude'][0] ) ) {
 				$geo_point['location']['lon'] = $post_meta['longitude'][0];
 			}
+		} elseif ( !empty( get_post_meta( $post_id, 'latitude', true ) ) ) {
+
+			if ( ! empty( $meta['latitude'][0]['double'] ) ) {
+				$lat = get_post_meta( $post_id, 'latitude', true );
+				$geo_point['location']['lat'] = $lat;
+				$post_args['meta']['latitude'][0]['double'] = $lat;
+			}
+
+			if ( ! empty( $meta['longitude'][0]['double'] ) ) {
+				$lon = get_post_meta( $post_id, 'longitude', true );
+				$geo_point['location']['lon'] = $lon;
+				$post_args['meta']['longitude'][0]['double'] = $lon;
+			}
 		}
 
 		$post_args['geo_point'] = apply_filters( 'ep_geo_post_sync_geo_point', $geo_point, $post_args, $post_id );


### PR DESCRIPTION
This may be at the root of recent indexing issues on a certain client site. For whatever reason, the $post_args array no longer seems to contain the meta fields from ACF, where it's kind of assumed that lat/long will be stored. It's not clear to me whether this is ideal for precedence, ie whether those post fields are getting updated by a post-save action for the purposes of `get_field` before or after this hook fires. But latitude and longitude don't change _that_ much for map locations, so presumably even if there is a precedence issue, the indexing will pick up the change the next time a sync is called?